### PR TITLE
Revamp homepage into personal site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# liuallen.com — Allen Liu (Min Liu)
+# liuallen.com - Allen Liu (Min Liu)
 
 Personal website for Allen Liu (Min Liu): AI/VC ecosystem builder, SVTR founder, and AI infrastructure + venture operator. The site is a single-page Next.js export hosted on Cloudflare Pages with a serverless contact endpoint using Pages Functions and MailChannels.
 
@@ -7,19 +7,19 @@ Personal website for Allen Liu (Min Liu): AI/VC ecosystem builder, SVTR founder,
 - **Build command:** `pnpm install --frozen-lockfile && pnpm --filter web build`
 - **Output directory:** `apps/web/out`
 
-Environment variables to set in Cloudflare Pages (Project → Settings → Environment Variables):
-- `CONTACT_TO_EMAIL` — destination inbox for contact form messages (required)
-- `CONTACT_FROM_EMAIL` — sender email to use with MailChannels (required)
-- `TURNSTILE_SECRET` — Turnstile secret key for server-side verification (optional but recommended)
-- `TURNSTILE_SITEKEY` — Turnstile site key (optional; pairs with `NEXT_PUBLIC_TURNSTILE_SITEKEY`)
-- `NEXT_PUBLIC_TURNSTILE_SITEKEY` — expose the site key to the client so the widget renders (optional)
+Environment variables to set in Cloudflare Pages (Project Settings -> Environment Variables):
+- `CONTACT_TO_EMAIL` - destination inbox for contact form messages (required)
+- `CONTACT_FROM_EMAIL` - sender email to use with MailChannels (required)
+- `TURNSTILE_SECRET` - Turnstile secret key for server-side verification (optional but recommended)
+- `TURNSTILE_SITEKEY` - Turnstile site key (optional; pairs with `NEXT_PUBLIC_TURNSTILE_SITEKEY`)
+- `NEXT_PUBLIC_TURNSTILE_SITEKEY` - expose the site key to the client so the widget renders (optional)
 
 ## Local development
 ```bash
 pnpm install
 pnpm --filter web dev
 ```
-The site runs at `http://localhost:3000`. The contact form will attempt to POST to `/api/contact`; you can test locally with Wrangler’s Pages dev server or stub the endpoint by running `pnpm wrangler pages dev` from the repo root.
+The site runs at `http://localhost:3000`. The contact form will attempt to POST to `/api/contact`; you can test locally with Wrangler's Pages dev server or stub the endpoint by running `pnpm wrangler pages dev` from the repo root.
 
 Build locally to mirror Cloudflare Pages:
 ```bash
@@ -32,6 +32,11 @@ The static export lands in `apps/web/out`.
 - Validates name/email/message, enforces Turnstile verification when keys are provided, and applies a best-effort in-memory rate limit when Turnstile is absent.
 - Sends mail via MailChannels using `CONTACT_FROM_EMAIL` as the sender and `CONTACT_TO_EMAIL` as the recipient. If sending fails, the response includes a helpful error message.
 - Optional Turnstile widget is rendered on the client when `NEXT_PUBLIC_TURNSTILE_SITEKEY` is set; otherwise requests rely on rate limiting.
+
+## Updating links and content
+- **Cal.com link**: update the `https://cal.com/PLACEHOLDER` URL in `apps/web/pages/index.tsx` and `apps/web/pages/contact.tsx`.
+- **Writing links**: replace the placeholder writing items in `apps/web/pages/index.tsx` (search for `Latest writing`) with real post links.
+- **Projects**: edit the "Selected projects" cards in `apps/web/pages/index.tsx` to point to live URLs (or remove placeholders).
 
 ## Routing and domains
 - `_redirects` ensures `www.liuallen.com` redirects to `https://liuallen.com` and that any unknown route falls back to `/index.html` (useful for SPA-style navigation).

--- a/apps/web/pages/contact.tsx
+++ b/apps/web/pages/contact.tsx
@@ -2,22 +2,22 @@ import Head from 'next/head';
 
 export default function ContactPage() {
   return (
-    <main style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 20px' }}>
+    <main style={{ maxWidth: '760px', margin: '0 auto', padding: '48px 20px' }}>
       <Head>
-        <title>Contact — Allen Liu</title>
+        <title>Contact - Allen Liu</title>
         <meta name="description" content="Contact Allen Liu for investing, partnerships, media, or build studio." />
       </Head>
       <h1 style={{ marginBottom: '0.5rem' }}>Contact</h1>
-      <p style={{ marginTop: 0, color: '#475569' }}>
-        Prefer forms? Visit the <a href="/#contact">contact section on the homepage</a> to send a note. Otherwise, reach me
-        directly at <a href="mailto:allen@liuallen.com">allen@liuallen.com</a> or schedule a call below.
+      <p style={{ marginTop: 0, color: '#4b5563' }}>
+        For the fastest response, use the <a href="/#contact">homepage contact form</a>. You can also reach me directly at{' '}
+        <a href="mailto:allen@liuallen.com">allen@liuallen.com</a> or schedule a call.
       </p>
       <div style={{ marginTop: '1.5rem', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
         <a
           href="https://cal.com/PLACEHOLDER"
           style={{
-            background: '#7c3aed',
-            color: '#fff',
+            background: 'linear-gradient(135deg, #f97316, #f59e0b)',
+            color: '#0b0f1a',
             padding: '12px 16px',
             borderRadius: '12px',
             textDecoration: 'none',
@@ -29,17 +29,21 @@ export default function ContactPage() {
         <a
           href="mailto:allen@liuallen.com"
           style={{
-            border: '1px solid #cbd5e1',
-            color: '#0f172a',
+            border: '1px solid #e6e2dc',
+            color: '#0b0f1a',
             padding: '12px 16px',
             borderRadius: '12px',
             textDecoration: 'none',
             fontWeight: 600,
+            background: '#fff',
           }}
         >
           Email
         </a>
       </div>
+      <p style={{ marginTop: '2rem', color: '#4b5563' }}>
+        Looking for projects? Visit the <a href="/apps">app store</a> or browse the <a href="/writing">writing page</a>.
+      </p>
     </main>
   );
 }

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -11,58 +11,274 @@ declare global {
   }
 }
 
+type Language = 'en' | 'zh';
 type FormState = 'idle' | 'submitting' | 'success' | 'error';
 
-const currentRoles = [
-  {
-    title: 'SVTR (svtr.ai)',
-    description: 'Founder of SVTR.ai — building a cross-border AI founder and investor network.',
-    href: 'https://svtr.ai',
-  },
-  {
-    title: 'PK Capital',
-    description: 'Partnering with PK Capital on AI investments and market expansion.',
-    href: 'https://pk.capital',
-  },
-  {
-    title: 'AI Coding Studio',
-    description: 'Hands-on build studio helping founders ship AI products and web apps quickly.',
-    href: '#contact',
-  },
+const topicOptions = [
+  { value: 'investing', label: { en: 'Investing', zh: '投资' } },
+  { value: 'partnership', label: { en: 'Partnership', zh: '合作' } },
+  { value: 'media', label: { en: 'Media', zh: '媒体' } },
+  { value: 'events', label: { en: 'Events', zh: '活动' } },
+  { value: 'build-studio', label: { en: 'Build Studio', zh: '搭建工作室' } },
+  { value: 'other', label: { en: 'Other', zh: '其他' } },
 ];
 
-const products = [
-  {
-    title: 'SVTR AI 创投库',
-    description: 'A curated database for AI founders and investors (private beta).',
+const copy = {
+  en: {
+    nav: {
+      about: 'What I do',
+      projects: 'Projects',
+      writing: 'Writing',
+      contact: 'Contact',
+      apps: 'Apps',
+    },
+    hero: {
+      title: 'Allen Liu (Min Liu)',
+      oneLiner:
+        'Building SVTR.ai — a cross-border AI founder & investor network. I invest and incubate AI startups, and run an AI build studio that helps founders ship products fast.',
+      primaryCta: 'Book a call',
+      secondaryCta: 'Email',
+      availability: 'Based near Stanford / Palo Alto. Open to: founders, investors, partners.',
+      badges: ['AI founders + investors', 'Cross-border network', 'Silicon Valley'],
+      cardTitle: 'SVTR.ai ecosystem',
+      cardBody:
+        'Media, community, events, and a database that connect AI founders, investors, and operators across the U.S. and China.',
+      cardCta: 'Explore SVTR.ai',
+    },
+    whatIDo: {
+      kicker: 'What I do',
+      title: 'Building the SVTR.ai ecosystem',
+      subtitle: 'Three ways I support AI founders and investors.',
+      cards: [
+        {
+          title: 'SVTR.ai Ecosystem',
+          description: 'Media + community + events + database bridging US–China AI founders/investors.',
+        },
+        {
+          title: 'Investing & Incubation',
+          description: 'Early-stage AI + infrastructure focus; connect capital, customers, and talent.',
+        },
+        {
+          title: 'AI Build Studio',
+          description: 'We help non-technical founders build websites/apps fast with high-quality engineering.',
+        },
+      ],
+    },
+    projects: {
+      kicker: 'Selected projects',
+      title: 'Projects & initiatives',
+      subtitle: 'Focused on ecosystem building, investing, and founder enablement.',
+      cards: [
+        {
+          title: 'SVTR.ai',
+          description: 'Cross-border AI founder & investor network.',
+          href: 'https://svtr.ai',
+          linkLabel: 'Visit SVTR.ai',
+        },
+        {
+          title: 'AI 创投库',
+          description: 'Curated AI founder/investor database.',
+          href: '#',
+          linkLabel: 'Private beta',
+          disabled: true,
+        },
+        {
+          title: 'AI 创投会 / AI 创投营',
+          description: 'Founder-first salons and sprints for building and fundraising.',
+          href: '#',
+          linkLabel: 'Coming soon',
+          disabled: true,
+        },
+        {
+          title: 'PK Capital',
+          description: 'Operator support for AI investment and expansion.',
+          href: '#',
+          linkLabel: 'Placeholder',
+          disabled: true,
+        },
+        {
+          title: 'Apps',
+          description: 'My product experiments and app store.',
+          href: '/apps',
+          linkLabel: 'Open /apps',
+        },
+      ],
+    },
+    writing: {
+      kicker: 'Latest writing',
+      title: 'Notes from the field',
+      subtitle: 'Research, community insights, and founder notes.',
+      items: [
+        {
+          title: 'Building founder density across borders',
+          href: '/writing',
+          meta: 'Placeholder',
+        },
+        {
+          title: 'What AI infra teams need to ship faster',
+          href: '/writing',
+          meta: 'Placeholder',
+        },
+        {
+          title: 'Operator playbooks for early-stage AI',
+          href: '/writing',
+          meta: 'Placeholder',
+        },
+      ],
+    },
+    contact: {
+      kicker: 'Contact',
+      title: "Let's build together",
+      subtitle: 'Book a call, send an email, or share the details below.',
+      note:
+        'I respond fastest with context: who you are, what you are building, and how I can help.',
+      emailLabel: 'Email: allen@liuallen.com',
+      form: {
+        name: 'Name',
+        email: 'Email',
+        topic: 'Topic',
+        message: 'Message',
+        submit: 'Send message',
+        sending: 'Sending…',
+        success: 'Message sent!',
+      },
+    },
   },
-  {
-    title: 'AI 创投会 / 创投营',
-    description: 'Founder-first salons and sprints for building and fundraising.',
+  zh: {
+    nav: {
+      about: '我在做什么',
+      projects: '项目',
+      writing: '写作',
+      contact: '联系',
+      apps: '应用',
+    },
+    hero: {
+      title: 'Allen Liu (Min Liu)',
+      oneLiner:
+        '打造 SVTR.ai——连接中美 AI 创业者与投资人的跨境网络。我投资并孵化 AI 初创公司，也运营 AI 搭建工作室，帮助创始人快速落地产品。',
+      primaryCta: '预约电话',
+      secondaryCta: '发送邮件',
+      availability: '常驻斯坦福 / 帕洛阿尔托附近。开放合作：创业者、投资人、合作伙伴。',
+      badges: ['AI 创业者 + 投资人', '跨境生态', '硅谷'],
+      cardTitle: 'SVTR.ai 生态',
+      cardBody: '媒体、社区、活动与数据库，连接中美 AI 创业者、投资人和运营者。',
+      cardCta: '了解 SVTR.ai',
+    },
+    whatIDo: {
+      kicker: '我在做什么',
+      title: '建设 SVTR.ai 生态',
+      subtitle: '支持 AI 创业者与投资人的三种方式。',
+      cards: [
+        {
+          title: 'SVTR.ai 生态',
+          description: '媒体 + 社区 + 活动 + 数据库，连接中美 AI 创业者/投资人。',
+        },
+        {
+          title: '投资与孵化',
+          description: '聚焦早期 AI 与基础设施，连接资本、客户与人才。',
+        },
+        {
+          title: 'AI 搭建工作室',
+          description: '帮助非技术创始人快速搭建网站/应用，工程质量可靠。',
+        },
+      ],
+    },
+    projects: {
+      kicker: '精选项目',
+      title: '项目与计划',
+      subtitle: '围绕生态建设、投资与创始人赋能。',
+      cards: [
+        {
+          title: 'SVTR.ai',
+          description: '跨境 AI 创业者与投资人网络。',
+          href: 'https://svtr.ai',
+          linkLabel: '访问 SVTR.ai',
+        },
+        {
+          title: 'AI 创投库',
+          description: '精选 AI 创业者/投资人数据库。',
+          href: '#',
+          linkLabel: '内测中',
+          disabled: true,
+        },
+        {
+          title: 'AI 创投会 / AI 创投营',
+          description: '面向创始人的沙龙与加速营。',
+          href: '#',
+          linkLabel: '即将发布',
+          disabled: true,
+        },
+        {
+          title: 'PK Capital',
+          description: 'AI 投资与扩张的运营支持。',
+          href: '#',
+          linkLabel: '占位中',
+          disabled: true,
+        },
+        {
+          title: '应用商店',
+          description: '我的产品实验与应用商店。',
+          href: '/apps',
+          linkLabel: '打开 /apps',
+        },
+      ],
+    },
+    writing: {
+      kicker: '最新写作',
+      title: '一线笔记',
+      subtitle: '研究、社区洞察与创始人笔记。',
+      items: [
+        {
+          title: '跨境生态的创始人密度',
+          href: '/writing',
+          meta: '占位',
+        },
+        {
+          title: 'AI 基础设施团队如何更快交付',
+          href: '/writing',
+          meta: '占位',
+        },
+        {
+          title: '早期 AI 的运营方法论',
+          href: '/writing',
+          meta: '占位',
+        },
+      ],
+    },
+    contact: {
+      kicker: '联系',
+      title: '一起共建',
+      subtitle: '预约电话、发送邮件，或填写表单。',
+      note: '我会优先回复信息完整的联系：你是谁、在做什么、需要我怎么支持。',
+      emailLabel: '邮箱：allen@liuallen.com',
+      form: {
+        name: '姓名',
+        email: '邮箱',
+        topic: '主题',
+        message: '内容',
+        submit: '发送',
+        sending: '发送中…',
+        success: '已发送！',
+      },
+    },
   },
-  {
-    title: 'Founder market labs',
-    description: 'Rapid go-to-market experiments with cross-border distribution.',
-  },
-  {
-    title: 'Operator circles',
-    description: 'Peer groups for AI infra builders, PMs, and growth leaders.',
-  },
-];
-
-const writingLinks = [
-  { label: 'Substack (coming soon)', href: 'https://substack.com/@liuallen' },
-  { label: 'LinkedIn updates', href: 'https://www.linkedin.com/in/liuallen/' },
-];
+};
 
 export default function HomePage() {
   const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITEKEY;
+  const [language, setLanguage] = useState<Language>('en');
   const [formState, setFormState] = useState<FormState>('idle');
   const [error, setError] = useState('');
   const [turnstileToken, setTurnstileToken] = useState('');
-  const [formValues, setFormValues] = useState({ name: '', email: '', message: '' });
+  const [formValues, setFormValues] = useState({
+    name: '',
+    email: '',
+    topic: topicOptions[0].value,
+    message: '',
+  });
   const [turnstileReady, setTurnstileReady] = useState(false);
   const turnstileContainerRef = useRef<HTMLDivElement | null>(null);
+  const t = copy[language];
 
   useEffect(() => {
     if (!turnstileSiteKey) return;
@@ -107,13 +323,16 @@ export default function HomePage() {
       return;
     }
 
+    const selectedTopic = topicOptions.find((topic) => topic.value === formValues.topic);
+    const topicLabel = selectedTopic?.label[language] ?? selectedTopic?.label.en ?? formValues.topic;
+
     try {
       const response = await fetch('/api/contact', {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ ...formValues, turnstileToken }),
+        body: JSON.stringify({ ...formValues, topic: topicLabel, turnstileToken }),
       });
 
       const payload = await response.json().catch(() => ({}));
@@ -126,7 +345,7 @@ export default function HomePage() {
       }
 
       setFormState('success');
-      setFormValues({ name: '', email: '', message: '' });
+      setFormValues({ name: '', email: '', topic: topicOptions[0].value, message: '' });
       setTurnstileToken('');
     } catch (err) {
       console.error(err);
@@ -135,24 +354,20 @@ export default function HomePage() {
     }
   };
 
-  const heroDescription = useMemo(
-    () =>
-      'AI/VC ecosystem builder, SVTR founder, and hands-on partner for AI infrastructure and venture teams.',
-    [],
-  );
+  const heroDescription = useMemo(() => t.hero.oneLiner, [t.hero.oneLiner]);
 
   return (
     <div className={styles.page}>
       <Head>
-        <title>Allen Liu (Min Liu) — AI/VC ecosystem builder</title>
+        <title>Allen Liu (Min Liu) — SVTR.ai founder</title>
         <meta
           name="description"
-          content="Allen Liu (Min Liu): SVTR founder, AI/VC ecosystem builder, and AI infrastructure + venture operator."
+          content="Allen Liu (Min Liu): building SVTR.ai, investing in AI startups, and operating a Silicon Valley build studio."
         />
-        <meta property="og:title" content="Allen Liu (Min Liu) — AI/VC ecosystem builder" />
+        <meta property="og:title" content="Allen Liu (Min Liu) — SVTR.ai founder" />
         <meta
           property="og:description"
-          content="SVTR founder building AI communities, products, and venture platforms across Silicon Valley and Asia."
+          content="Building SVTR.ai, investing in AI startups, and operating an AI build studio for founders."
         />
         <meta property="og:url" content="https://liuallen.com" />
         <meta property="og:type" content="website" />
@@ -160,7 +375,7 @@ export default function HomePage() {
         <meta name="twitter:title" content="Allen Liu (Min Liu)" />
         <meta
           name="twitter:description"
-          content="AI/VC ecosystem builder, SVTR founder, and AI infrastructure + venture partner."
+          content="SVTR.ai founder, AI investor, and operator for fast-moving founder teams."
         />
         <link rel="canonical" href="https://liuallen.com" />
         <link rel="icon" href="/favicon.svg" />
@@ -171,88 +386,112 @@ export default function HomePage() {
           <div className={styles.brand}>
             <span className={styles.brandDot} aria-hidden />
             <div>
-              <span>Allen Liu (Min Liu)</span>
-              <span className={styles.brandMeta}>AI/VC ecosystem • SVTR founder</span>
+              <span>{t.hero.title}</span>
+              <span className={styles.brandMeta}>SVTR.ai founder · AI investor</span>
             </div>
           </div>
-          <nav className={styles.navLinks} aria-label="Primary navigation">
-            <a href="#current">Current</a>
-            <a href="#products">Projects</a>
-            <a href="#writing">Writing</a>
-            <a href="#contact">Contact</a>
-          </nav>
+          <div className={styles.navRight}>
+            <nav className={styles.navLinks} aria-label="Primary navigation">
+              <a href="#what-i-do">{t.nav.about}</a>
+              <a href="#projects">{t.nav.projects}</a>
+              <a href="#writing">{t.nav.writing}</a>
+              <a href="#contact">{t.nav.contact}</a>
+              <a href="/apps">{t.nav.apps}</a>
+            </nav>
+            <div className={styles.langToggle} role="group" aria-label="Language toggle">
+              <button
+                className={`${styles.langButton} ${language === 'en' ? styles.langButtonActive : ''}`}
+                type="button"
+                aria-pressed={language === 'en'}
+                onClick={() => setLanguage('en')}
+              >
+                EN
+              </button>
+              <button
+                className={`${styles.langButton} ${language === 'zh' ? styles.langButtonActive : ''}`}
+                type="button"
+                aria-pressed={language === 'zh'}
+                onClick={() => setLanguage('zh')}
+              >
+                中文
+              </button>
+            </div>
+          </div>
         </header>
 
         <section className={styles.hero}>
           <div>
             <div className={styles.badges}>
-              <span className={styles.badge}>AI infrastructure & venture</span>
-              <span className={styles.badge}>Based in Silicon Valley</span>
+              {t.hero.badges.map((badge) => (
+                <span key={badge} className={styles.badge}>
+                  {badge}
+                </span>
+              ))}
             </div>
-            <h1>Allen Liu (Min Liu)</h1>
+            <h1>{t.hero.title}</h1>
             <p className={styles.heroSubtitle}>{heroDescription}</p>
             <div className={styles.ctaRow}>
-              <a className={styles.primaryBtn} href="#contact">
-                Contact Allen
+              <a className={styles.primaryBtn} href="https://cal.com/PLACEHOLDER" target="_blank" rel="noreferrer">
+                {t.hero.primaryCta}
               </a>
-              <a className={styles.secondaryBtn} href="https://cal.com/liuallen/intro" target="_blank" rel="noreferrer">
-                Book a call
+              <a className={styles.secondaryBtn} href="mailto:allen@liuallen.com">
+                {t.hero.secondaryCta}
               </a>
             </div>
-            <p className={styles.subtle}>AI/VC ecosystem builder • Founder of SVTR • Operator for AI infrastructure teams</p>
+            <p className={styles.heroNote}>{t.hero.availability}</p>
           </div>
           <div className={styles.heroCard}>
-            <small>Now</small>
-            <h3>SVTR founder & community builder</h3>
-            <p>
-              SVTR bridges AI founders, investors, and operators across the U.S. and Asia with media, research, and curated
-              programs.
-            </p>
+            <small>SVTR.ai</small>
+            <h3>{t.hero.cardTitle}</h3>
+            <p>{t.hero.cardBody}</p>
             <a className={styles.secondaryBtn} href="https://svtr.ai" target="_blank" rel="noreferrer">
-              Explore SVTR.ai
+              {t.hero.cardCta}
             </a>
           </div>
         </section>
 
-        <section id="current" className={styles.section}>
+        <section id="what-i-do" className={styles.section}>
           <div className={styles.sectionHeader}>
             <div>
-              <p className={styles.subtle}>Current</p>
-              <h2 className={styles.sectionTitle}>What I&apos;m building</h2>
+              <p className={styles.subtle}>{t.whatIDo.kicker}</p>
+              <h2 className={styles.sectionTitle}>{t.whatIDo.title}</h2>
+              <p className={styles.sectionSubtitle}>{t.whatIDo.subtitle}</p>
             </div>
           </div>
           <div className={styles.cardGrid}>
-            {currentRoles.map((role) => (
+            {t.whatIDo.cards.map((role) => (
               <article key={role.title} className={styles.card}>
-                <div className={styles.cardTitleRow}>
-                  <h3>{role.title}</h3>
-                  <span aria-hidden>↗</span>
-                </div>
+                <h3>{role.title}</h3>
                 <p>{role.description}</p>
-                <a href={role.href} target={role.href.startsWith('http') ? '_blank' : undefined} rel="noreferrer">
-                  Learn more
-                </a>
               </article>
             ))}
           </div>
         </section>
 
-        <section id="products" className={styles.section}>
+        <section id="projects" className={styles.section}>
           <div className={styles.sectionHeader}>
             <div>
-              <p className={styles.subtle}>Projects / Products</p>
-              <h2 className={styles.sectionTitle}>Building with founders</h2>
-              <p className={styles.sectionSubtitle}>SVTR AI 创投库、AI 创投会 / 创投营，以及精选产品与计划。</p>
+              <p className={styles.subtle}>{t.projects.kicker}</p>
+              <h2 className={styles.sectionTitle}>{t.projects.title}</h2>
+              <p className={styles.sectionSubtitle}>{t.projects.subtitle}</p>
             </div>
           </div>
           <div className={styles.cardGrid}>
-            {products.map((project) => (
+            {t.projects.cards.map((project) => (
               <article key={project.title} className={styles.card}>
                 <div className={styles.cardTitleRow}>
                   <h3>{project.title}</h3>
-                  <span aria-hidden>•</span>
                 </div>
                 <p>{project.description}</p>
+                {project.href ? (
+                  project.disabled ? (
+                    <span className={styles.cardNote}>{project.linkLabel}</span>
+                  ) : (
+                    <a href={project.href} className={styles.cardLink} target={project.href.startsWith('http') ? '_blank' : undefined} rel="noreferrer">
+                      {project.linkLabel}
+                    </a>
+                  )
+                ) : null}
               </article>
             ))}
           </div>
@@ -261,19 +500,22 @@ export default function HomePage() {
         <section id="writing" className={styles.section}>
           <div className={styles.sectionHeader}>
             <div>
-              <p className={styles.subtle}>Writing / Speaking</p>
-              <h2 className={styles.sectionTitle}>Sharing notes</h2>
-              <p className={styles.sectionSubtitle}>Long-form posts and updates on AI infrastructure, venture, and community.</p>
+              <p className={styles.subtle}>{t.writing.kicker}</p>
+              <h2 className={styles.sectionTitle}>{t.writing.title}</h2>
+              <p className={styles.sectionSubtitle}>{t.writing.subtitle}</p>
             </div>
           </div>
           <div className={styles.list}>
-            {writingLinks.map((item) => (
-              <div key={item.label} className={styles.listItem}>
-                <span>{item.label}</span>
-                <a href={item.href} target="_blank" rel="noreferrer">
-                  Follow ↗
-                </a>
-              </div>
+            {t.writing.items.map((item) => (
+              <a key={item.title} className={styles.listItem} href={item.href}>
+                <div>
+                  <h3 className={styles.listTitle}>{item.title}</h3>
+                  <span className={styles.listMeta}>{item.meta}</span>
+                </div>
+                <span className={styles.listArrow} aria-hidden>
+                  ↗
+                </span>
+              </a>
             ))}
           </div>
         </section>
@@ -281,17 +523,15 @@ export default function HomePage() {
         <section id="contact" className={styles.section}>
           <div className={styles.sectionHeader}>
             <div>
-              <p className={styles.subtle}>Contact</p>
-              <h2 className={styles.sectionTitle}>Let&apos;s collaborate</h2>
-              <p className={styles.sectionSubtitle}>
-                Reach out for AI investments, SVTR partnerships, build studio help, or speaking requests.
-              </p>
+              <p className={styles.subtle}>{t.contact.kicker}</p>
+              <h2 className={styles.sectionTitle}>{t.contact.title}</h2>
+              <p className={styles.sectionSubtitle}>{t.contact.subtitle}</p>
               <div className={styles.inlineActions}>
-                <a className={styles.primaryBtn} href="mailto:contact@liuallen.com">
-                  Email Allen
+                <a className={styles.primaryBtn} href="https://cal.com/PLACEHOLDER" target="_blank" rel="noreferrer">
+                  {t.hero.primaryCta}
                 </a>
-                <a className={styles.secondaryBtn} href="https://cal.com/liuallen/intro" target="_blank" rel="noreferrer">
-                  Book a call
+                <a className={styles.secondaryBtn} href="mailto:allen@liuallen.com">
+                  {t.hero.secondaryCta}
                 </a>
               </div>
             </div>
@@ -299,15 +539,12 @@ export default function HomePage() {
 
           <div className={styles.contactLayout}>
             <div>
-              <p className={styles.subtle}>
-                I reply fastest with context. Share what you&apos;re building, what you need, and how SVTR or the AI Coding Studio can
-                help.
-              </p>
-              <p className={styles.subtle}>All inquiries go directly to me.</p>
+              <p className={styles.subtle}>{t.contact.note}</p>
+              <p className={styles.subtle}>{t.contact.emailLabel}</p>
             </div>
             <form className={styles.contactForm} onSubmit={handleSubmit}>
               <div className={styles.field}>
-                <label htmlFor="name">Name</label>
+                <label htmlFor="name">{t.contact.form.name}</label>
                 <input
                   id="name"
                   name="name"
@@ -318,7 +555,7 @@ export default function HomePage() {
                 />
               </div>
               <div className={styles.field}>
-                <label htmlFor="email">Email</label>
+                <label htmlFor="email">{t.contact.form.email}</label>
                 <input
                   id="email"
                   name="email"
@@ -330,7 +567,23 @@ export default function HomePage() {
                 />
               </div>
               <div className={styles.field}>
-                <label htmlFor="message">Message</label>
+                <label htmlFor="topic">{t.contact.form.topic}</label>
+                <select
+                  id="topic"
+                  name="topic"
+                  value={formValues.topic}
+                  required
+                  onChange={(e) => setFormValues({ ...formValues, topic: e.target.value })}
+                >
+                  {topicOptions.map((topic) => (
+                    <option key={topic.value} value={topic.value}>
+                      {topic.label[language]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className={styles.field}>
+                <label htmlFor="message">{t.contact.form.message}</label>
                 <textarea
                   id="message"
                   name="message"
@@ -343,10 +596,18 @@ export default function HomePage() {
               {turnstileSiteKey ? <div className={styles.turnstileBox} ref={turnstileContainerRef} /> : null}
               <div className={styles.inlineActions}>
                 <button className={styles.primaryBtn} type="submit" disabled={formState === 'submitting'}>
-                  {formState === 'submitting' ? 'Sending…' : 'Send message'}
+                  {formState === 'submitting' ? t.contact.form.sending : t.contact.form.submit}
                 </button>
-                {formState === 'success' && <p className={`${styles.status} ${styles.success}`}>Message sent!</p>}
-                {formState === 'error' && <p className={`${styles.status} ${styles.error}`}>{error}</p>}
+                {formState === 'success' && (
+                  <p className={`${styles.status} ${styles.success}`} aria-live="polite">
+                    {t.contact.form.success}
+                  </p>
+                )}
+                {formState === 'error' && (
+                  <p className={`${styles.status} ${styles.error}`} aria-live="polite">
+                    {error}
+                  </p>
+                )}
               </div>
             </form>
           </div>

--- a/apps/web/pages/writing.tsx
+++ b/apps/web/pages/writing.tsx
@@ -2,24 +2,24 @@ import Head from 'next/head';
 
 export default function WritingPage() {
   return (
-    <main style={{ maxWidth: '720px', margin: '0 auto', padding: '40px 20px' }}>
+    <main style={{ maxWidth: '760px', margin: '0 auto', padding: '48px 20px' }}>
       <Head>
-        <title>Writing — Allen Liu</title>
+        <title>Writing - Allen Liu</title>
         <meta name="description" content="Writing and notes by Allen Liu." />
       </Head>
       <h1 style={{ marginBottom: '0.5rem' }}>Writing</h1>
-      <p style={{ marginTop: 0, color: '#475569' }}>
-        Long-form essays and notes will live here soon. For now, browse highlights on the homepage or reach out directly.
+      <p style={{ marginTop: 0, color: '#4b5563' }}>
+        Longer essays and field notes will live here. For now, explore featured updates on the homepage.
       </p>
-      <ul style={{ marginTop: '1.5rem', lineHeight: 1.6 }}>
+      <ul style={{ marginTop: '1.5rem', lineHeight: 1.6, paddingLeft: '1.2rem' }}>
         <li>
-          Visit <a href="/">the homepage</a> for the latest featured posts.
+          Visit <a href="/">the homepage</a> for highlights and contact.
         </li>
         <li>
-          Check out <a href="/apps">the apps page</a> for product experiments.
+          Explore <a href="/apps">the app store</a> for product experiments.
         </li>
         <li>
-          Email <a href="mailto:allen@liuallen.com">allen@liuallen.com</a> if you want early drafts.
+          Email <a href="mailto:allen@liuallen.com">allen@liuallen.com</a> if you want drafts.
         </li>
       </ul>
     </main>

--- a/apps/web/styles/Home.module.css
+++ b/apps/web/styles/Home.module.css
@@ -6,9 +6,9 @@
 
 .shell {
   width: 100%;
-  max-width: 1100px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 28px 20px 64px;
+  padding: 28px 20px 72px;
 }
 
 .navbar {
@@ -16,11 +16,11 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 0;
+  padding: 12px 0 18px;
   position: sticky;
   top: 0;
-  background: rgba(247, 249, 252, 0.9);
-  backdrop-filter: blur(8px);
+  background: rgba(248, 247, 244, 0.92);
+  backdrop-filter: blur(10px);
   z-index: 10;
 }
 
@@ -36,35 +36,70 @@
   width: 14px;
   height: 14px;
   border-radius: 999px;
-  background: linear-gradient(135deg, #7c3aed, #22c55e);
-  box-shadow: 0 0 0 6px rgba(124, 58, 237, 0.15);
+  background: linear-gradient(135deg, #f97316, #0ea5e9);
+  box-shadow: 0 0 0 6px rgba(249, 115, 22, 0.18);
 }
 
 .brandMeta {
   display: block;
-  color: #475569;
+  color: var(--muted);
   font-weight: 500;
   font-size: 0.95rem;
+}
+
+.navRight {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .navLinks {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 16px;
   font-weight: 600;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .navLinks a {
-  color: #0f172a;
-  padding: 8px 10px;
-  border-radius: 12px;
+  color: var(--ink);
+  padding: 6px 10px;
+  border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .navLinks a:hover {
-  background: #ede9fe;
-  color: #5b21b6;
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
   text-decoration: none;
+}
+
+.langToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px;
+}
+
+.langButton {
+  border: none;
+  background: transparent;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.langButtonActive {
+  background: var(--ink);
+  color: #fff;
 }
 
 .primaryBtn,
@@ -73,7 +108,7 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 12px 16px;
+  padding: 12px 18px;
   border-radius: 12px;
   border: 1px solid transparent;
   font-weight: 700;
@@ -83,9 +118,9 @@
 }
 
 .primaryBtn {
-  background: linear-gradient(135deg, #7c3aed, #6d28d9);
-  color: #fff;
-  box-shadow: 0 10px 35px rgba(124, 58, 237, 0.35);
+  background: linear-gradient(135deg, #f97316, #f59e0b);
+  color: #0b0f1a;
+  box-shadow: 0 14px 30px rgba(249, 115, 22, 0.25);
 }
 
 .primaryBtn:hover {
@@ -95,12 +130,12 @@
 
 .secondaryBtn {
   background: #fff;
-  border-color: #e2e8f0;
-  color: #0f172a;
+  border-color: var(--border);
+  color: var(--ink);
 }
 
 .secondaryBtn:hover {
-  background: #f8fafc;
+  background: #fef3c7;
   text-decoration: none;
 }
 
@@ -108,7 +143,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 32px;
-  padding: 48px 0 24px;
+  padding: 48px 0 28px;
   align-items: center;
 }
 
@@ -119,23 +154,23 @@
 }
 
 .badge {
-  padding: 8px 12px;
+  padding: 6px 12px;
   border-radius: 999px;
-  background: #eef2ff;
-  color: #4338ca;
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
   font-weight: 700;
   font-size: 0.9rem;
 }
 
 .hero h1 {
-  font-size: clamp(2.2rem, 4vw, 2.8rem);
-  margin: 12px 0;
+  font-size: clamp(2.2rem, 4vw, 2.9rem);
+  margin: 14px 0;
   letter-spacing: -0.02em;
 }
 
 .heroSubtitle {
   font-size: 1.05rem;
-  color: #475569;
+  color: var(--muted);
   margin-bottom: 18px;
 }
 
@@ -146,29 +181,35 @@
   margin: 18px 0 8px;
 }
 
+.heroNote {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
 .heroCard {
-  background: #0b1021;
+  background: #0f172a;
   color: #e2e8f0;
   border-radius: 18px;
   padding: 24px;
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .heroCard small {
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #cbd5e1;
+  color: #fbbf24;
 }
 
 .heroCard h3 {
   margin: 10px 0 6px;
+  color: #fff;
 }
 
 .section {
   margin: 24px 0 12px;
   padding: 24px 0;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--border);
 }
 
 .sectionHeader {
@@ -181,13 +222,13 @@
 }
 
 .sectionTitle {
-  font-size: 1.6rem;
+  font-size: 1.7rem;
   margin: 0;
 }
 
 .sectionSubtitle {
   margin: 4px 0 0;
-  color: #475569;
+  color: var(--muted);
 }
 
 .cardGrid {
@@ -198,13 +239,13 @@
 
 .card {
   background: #fff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 16px;
   padding: 16px;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .cardTitleRow {
@@ -221,17 +262,28 @@
 
 .card p {
   margin: 0;
-  color: #475569;
+  color: var(--muted);
+}
+
+.cardLink {
+  font-weight: 600;
+  color: #0ea5e9;
+}
+
+.cardNote {
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-weight: 600;
 }
 
 .subtle {
-  color: #475569;
+  color: var(--muted);
   font-size: 0.95rem;
 }
 
 .list {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 .listItem {
@@ -239,10 +291,32 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 14px 16px;
+  padding: 16px;
   background: #fff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 14px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.listItem:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+  text-decoration: none;
+}
+
+.listTitle {
+  margin: 0 0 4px;
+  font-size: 1.05rem;
+}
+
+.listMeta {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.listArrow {
+  font-size: 1.1rem;
+  color: #0ea5e9;
 }
 
 .contactLayout {
@@ -254,7 +328,7 @@
 
 .contactForm {
   background: #fff;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 16px;
   padding: 18px;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
@@ -289,7 +363,7 @@
 .status {
   margin: 0;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--ink);
 }
 
 .success {
@@ -308,7 +382,7 @@
 }
 
 .footer {
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--border);
   padding: 18px 0 36px;
   margin-top: 32px;
   display: flex;
@@ -316,7 +390,7 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 10px;
-  color: #475569;
+  color: var(--muted);
 }
 
 .turnstileBox {
@@ -328,9 +402,9 @@
     position: static;
   }
 
-  .navLinks {
-    flex-wrap: wrap;
-    justify-content: flex-end;
+  .navRight {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .heroCard {

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,7 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap');
+
 :root {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #0f172a;
-  background-color: #f7f9fc;
+  font-family: 'Manrope', 'Segoe UI', system-ui, sans-serif;
+  --font-display: 'Space Grotesk', 'Manrope', 'Segoe UI', system-ui, sans-serif;
+  --ink: #0b0f1a;
+  --muted: #4b5563;
+  --bg: #f8f7f4;
+  --border: #e6e2dc;
+  color: var(--ink);
+  background-color: var(--bg);
   line-height: 1.6;
 }
 
@@ -11,10 +18,20 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.08), transparent 35%),
-    radial-gradient(circle at 80% 0%, rgba(34, 197, 94, 0.05), transparent 30%),
-    #f7f9fc;
-  color: #0f172a;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.12), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(249, 115, 22, 0.14), transparent 35%),
+    var(--bg);
+  color: var(--ink);
+  font-family: inherit;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
 }
 
 a {
@@ -36,6 +53,6 @@ button {
 }
 
 :focus-visible {
-  outline: 3px solid #7c3aed;
+  outline: 3px solid #0ea5e9;
   outline-offset: 2px;
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,8 +2,6 @@ name = "maildiary-worker"
 main = "apps/worker/src/index.ts"
 compatibility_date = "2024-05-01"
 workers_dev = false
-pages_build_command = "pnpm install --frozen-lockfile && pnpm --filter web build"
-pages_build_output_dir = "apps/web/out"
 
 [vars]
 APP_BASE_URL = "https://diary.liuallen.com"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,8 @@ name = "maildiary-worker"
 main = "apps/worker/src/index.ts"
 compatibility_date = "2024-05-01"
 workers_dev = false
+pages_build_command = "pnpm install --frozen-lockfile && pnpm --filter web build"
+pages_build_output_dir = "apps/web/out"
 
 [vars]
 APP_BASE_URL = "https://diary.liuallen.com"


### PR DESCRIPTION
## Summary
- Convert / into a bilingual personal homepage for Allen Liu (Min Liu)
- Preserve app store experience at /apps
- Add lead capture CTAs and topic-aware contact form (emails include topic)
- Refresh visual system and placeholders for /writing and /contact

## Notes
- Update the Cal.com link by replacing https://cal.com/PLACEHOLDER in pps/web/pages/index.tsx and pps/web/pages/contact.tsx.
- Update writing/project placeholders in pps/web/pages/index.tsx when ready.
- Contact endpoint uses CONTACT_TO_EMAIL / CONTACT_FROM_EMAIL and optional Turnstile keys; topic is included in emails.

## Testing
- Not run (not requested)