### PR TITLE
Temporary: return JSON on contact errors

### DIFF
--- a/functions/api/contact.ts
+++ b/functions/api/contact.ts
@@ -202,7 +202,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       const message =
         err instanceof Error ? err.message : 'Unable to deliver message. Please email instead.';
       return new Response(JSON.stringify({ ok: false, error: message }), {
-        status: 502,
+        status: 200,
         headers: { 'content-type': 'application/json' },
       });
     }
@@ -211,7 +211,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const message =
       err instanceof Error ? err.message : 'Unexpected error. Please email instead.';
     return new Response(JSON.stringify({ ok: false, error: message }), {
-      status: 500,
+      status: 200,
       headers: { 'content-type': 'application/json' },
     });
   }


### PR DESCRIPTION
## Summary
- Return JSON error payloads with 200 status to surface contact failures during debugging

## Testing
- Not run (not requested)
